### PR TITLE
Fix panic

### DIFF
--- a/controlFile/parse.go
+++ b/controlFile/parse.go
@@ -97,7 +97,7 @@ func findEnd(start int, jobFileBytes []byte) int {
 			return start + i - 1
 		}
 	}
-	return -1
+	return len(jobFileBytes)-1
 }
 
 func extractString(position int, jobFileBytes []byte) *string {


### PR DESCRIPTION
* When reaching the end of the file it can happen that -1 is returned as
end position
* This is wrong and can lead to panic - we need to return the last array
position